### PR TITLE
fix(schematics) change `format` script to use double quotes around the glob pattern

### DIFF
--- a/src/application/files/__directory__/package.json
+++ b/src/application/files/__directory__/package.json
@@ -9,7 +9,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "format": "prettier --single-quote --print-width 120 --write '{apps,libs}/**/*.ts'"
+    "format": "prettier --single-quote --print-width 120 --write \"{apps,libs}/**/*.ts\""
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
fix(schematics) change `format` script to use double quotes around the glob pattern

Node version: v8.6.0,
Npm version: 5.3.0,
Windows 10. 
Running `npm run format` in Nx Workspace (which also gets run after nx app/lib creation), results in an error `No matching files. Patterns tried: '{apps,libs}/**/*.ts' !**/node_modules/** !./node_modules/**`. Modifying to double qoutes around the glob pattern eliminates the error.